### PR TITLE
fix(openapi): correct indentation for ListProjectMembersV1Response schema

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1302,17 +1302,17 @@ components:
               member_id:
                 type: string
                 description: The unique identifier of the member
-                scopes:
-                  type: array
-                  items:
-                    type: string
-                  description: The API scopes of the member
+              scopes:
+                type: array
+                items:
+                  type: string
+                description: The API scopes of the member
               email:
                 type: string
-                first_name:
-                  type: string
-                last_name:
-                  type: string
+              first_name:
+                type: string
+              last_name:
+                type: string
     DeleteProjectMemberV1Response:
       type: object
       properties:


### PR DESCRIPTION
`scopes` was incorrectly nested under `member_id`'s description, and `first_name`/`last_name` were nested under `email.` This caused Fern-generated SDKs to miss these fields entirely, making member scopes and names inaccessible.