### PR TITLE
fix(asyncapi): correct required indentation in AgentV1SettingsMessage

### DIFF
--- a/asyncapi.yml
+++ b/asyncapi.yml
@@ -1834,10 +1834,10 @@ components:
               - type: string
                 format: uuid
                 description: The ID of an agent created using the agent builder
-          required:
-            - type
-            - audio
-            - agent
+        required:
+          - type
+          - audio
+          - agent
     AgentV1UpdateSpeakMessage:
       description: Send a message to change the Speak model in the middle of a conversation
       payload:


### PR DESCRIPTION
required: [type, audio, agent] was indented inside properties.agent's oneOf block instead of being a sibling of properties on the payload object. This caused two Spectral lint errors against the AsyncAPI 3.0 schema.