### PR TITLE
ci: poll developers.deepgram.com for spec updates

### DIFF
--- a/.github/workflows/sync-from-docs.yml
+++ b/.github/workflows/sync-from-docs.yml
@@ -1,0 +1,49 @@
+name: Sync specs from developers.deepgram.com
+
+on:
+  schedule:
+    - cron: '0 * * * *' # hourly
+  workflow_dispatch:
+
+jobs:
+  sync:
+    name: Poll and sync bundled specs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download specs
+        run: |
+          curl -sSf https://developers.deepgram.com/openapi.yaml -o /tmp/openapi.yml
+          curl -sSf https://developers.deepgram.com/asyncapi.yaml -o /tmp/asyncapi.yml
+
+      - name: Check for changes
+        id: diff
+        run: |
+          changed=false
+          if ! diff -q /tmp/openapi.yml openapi.yml > /dev/null 2>&1; then
+            changed=true
+            echo "OpenAPI spec changed"
+          fi
+          if ! diff -q /tmp/asyncapi.yml asyncapi.yml > /dev/null 2>&1; then
+            changed=true
+            echo "AsyncAPI spec changed"
+          fi
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+
+      - name: Commit updated specs
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          cp /tmp/openapi.yml openapi.yml
+          cp /tmp/asyncapi.yml asyncapi.yml
+
+          git config user.email "devrel@deepgram.com"
+          git config user.name "Deepgram DX Bot"
+
+          git add openapi.yml asyncapi.yml
+          git commit -m "chore(specs): sync from developers.deepgram.com"
+          git push

--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@ This repository contains [OpenAPI](https://www.openapis.org) and  [AsyncAPI](htt
 
 ## Public mirror
 
-This is a public mirror of the internal Deepgram API specifications. Pull requests to this spec document will not be merged. In the future, we may enable contributions and corrections via contribution to the spec, but for now they cannot be accepted. Thank you!
+This is a public mirror of the Deepgram API specifications published at [developers.deepgram.com](https://developers.deepgram.com). Specs are synced automatically every hour from:
+
+- `https://developers.deepgram.com/openapi.yaml`
+- `https://developers.deepgram.com/asyncapi.yaml`
+
+Pull requests from external contributors will not be merged. Thank you!
 
 ## Latest Public Version
 


### PR DESCRIPTION
## Summary

- Adds a new hourly workflow that polls `https://developers.deepgram.com/openapi.yaml` and `https://developers.deepgram.com/asyncapi.yaml` and commits any changes directly to main
- Updates README to document the new sync source

## Why

Fern now serves bundled spec files directly from the docs site (see [fern-api/fern#14933](https://github.com/fern-api/fern/issues/14933)). This means `deepgram-docs` no longer needs to push specs here — this repo can poll instead.

This removes the cross-repo PAT (`API_SPEC_SYNC_FGPAT`) requirement entirely. The workflow uses `GITHUB_TOKEN` only.

The companion change removing the old push workflow from `deepgram-docs` is in deepgram/deepgram-docs#790.